### PR TITLE
Synchronize trajectory rendering and auto-frame outfield views

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -13,10 +13,12 @@
     "color": "#2563EB",
     "line_width": 3.0,
     "ball_color": "#2563EB",
-    "ball_radius": 0.6
+    "ball_radius": 0.6,
+    "full_path_opacity": 0.0
   },
   "animation": {
-    "trail_segments": 0
+    "trail_segments": 0,
+    "line_delay_segments": 0
   },
   "overlay": {
     "text_color": "#333333"


### PR DESCRIPTION
## Summary
- align the animated trajectory line with the ball position and allow configurable line delays
- add optional full-path rendering controls in the theme and keep materials in sync on resize
- compute ballpark bounds and auto-frame outfield stand presets, reapplying on resize

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4336bfa88326851e23306b74d743