### PR TITLE
Animate trajectory line and sort plays chronologically

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -11,14 +11,11 @@
   },
   "trajectory": {
     "color": "#2563EB",
-    "line_width": 3.0,
-    "ball_color": "#2563EB",
-    "ball_radius": 0.6,
-    "full_path_opacity": 0.0
+    "line_width": 3.0
   },
   "animation": {
-    "trail_segments": 0,
-    "line_delay_segments": 0
+    "ft_per_sec": 150.0,
+    "ease": "linear"
   },
   "overlay": {
     "text_color": "#333333"


### PR DESCRIPTION
## Summary
- replace the ball mesh animation with a drawRange-driven Line2 trajectory that stretches over time using speed and easing from the theme
- ensure play lists are chronologically sorted and overlay fields are refreshed with normalized data on every selection, including CSV uploads
- expose the new animation speed/ease knobs in the theme configuration and clean up unused trajectory options

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db6b6290b883269409e5678f1a5763