### PR TITLE
Refine viewer trajectory animation and chronology

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -14,7 +14,9 @@
     "line_width": 3.0
   },
   "animation": {
-    "ft_per_sec": 150.0,
+    "mode": "line_only",
+    "duration_seconds": 4.0,
+    "ft_per_sec": 140.0,
     "ease": "linear"
   },
   "overlay": {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -75,10 +75,6 @@
     <div id="canvasWrap">
       <canvas id="glcanvas"></canvas>
     </div>
-    <div class="hint">
-      <p>ワイヤーフレーム表示：球場は線のみ、軌道は色付きで強調。<br />
-      <code>bundle-viewer --theme config/theme.json</code> で色や線幅を変更できます。</p>
-    </div>
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -87,7 +87,3 @@ html, body { height:100%; margin:0; font-family: system-ui, -apple-system, Segoe
 }
 #canvasWrap { position: absolute; top: var(--ui-offset, 74px); left:0; right:0; bottom:0; }
 #glcanvas { width:100%; height:100%; display:block; background:#f5f7fb; }
-.hint {
-  position: fixed; left:12px; bottom:12px; background: rgba(250,250,250,0.9);
-  padding:8px 12px; border:1px solid #e5e7eb; border-radius:6px; font-size:0.9rem; color:#4b5563;
-}


### PR DESCRIPTION
## Summary
- animate trajectories by progressively extending the line from home plate using easing, duration, and follow-target updates
- normalize and sort plays chronologically across playlist and CSV inputs while accepting embedded trajectory data
- refresh viewer chrome by removing the unused hint and updating animation defaults in the theme

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db93608b5c8326a2515b24b8710b30