### PR TITLE
Add progressive trajectory reveal with ghost tail

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -11,13 +11,20 @@
   },
   "trajectory": {
     "color": "#2563EB",
+    "ghost_color": "#93C5FD",
     "line_width": 3.0,
-    "ball_radius": 1.2
+    "ball_radius": 0.6
   },
   "animation": {
     "mode": "reveal_with_ball",
     "duration_seconds": 1.5,
-    "ease": "linear"
+    "ease": "linear",
+    "ghost": {
+      "enabled": true,
+      "segments": 80,
+      "opacity": 0.35
+    },
+    "strict_direction": true
   },
   "overlay": {
     "text_color": "#333333"


### PR DESCRIPTION
## Summary
- paint the trajectory progressively using a vertex-colored Line2 that stays aligned with the ball
- add an optional translucent ghost trail plus stricter direction handling during trajectory preparation
- extend the default theme with ghost configuration, updated ball radius, and trajectory colors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba8b70e088326a8aeddfd8162c756