### PR TITLE
Add painted trajectory reveal with ghost trail

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -11,13 +11,20 @@
   },
   "trajectory": {
     "color": "#2563EB",
+    "ghost_color": "#93C5FD",
     "line_width": 3.0,
-    "ball_radius": 1.2
+    "ball_radius": 0.6
   },
   "animation": {
     "mode": "reveal_with_ball",
     "duration_seconds": 1.5,
-    "ease": "linear"
+    "ease": "linear",
+    "ghost": {
+      "enabled": true,
+      "segments": 80,
+      "opacity": 0.35
+    },
+    "strict_direction": true
   },
   "overlay": {
     "text_color": "#333333"


### PR DESCRIPTION
## Summary
- add vertex-colored reveal path that paints the trajectory alongside the moving ball
- add optional ghost trail rendering and stricter direction heuristics for trajectories
- extend the theme to configure ghost styling, strict direction, and updated ball defaults

## Testing
- python -m mlbtraj.cli simulate data/samples/sample.csv --park lad-dodger-stadium --out out/lad --calibrate-distance
- python -m mlbtraj.cli bundle-viewer --playlist out/lad/playlist.json --park lad-dodger-stadium --dest dist/lad --theme config/theme.json

------
https://chatgpt.com/codex/tasks/task_e_68dbb31fe2e083268092a17174e4e262