### PR TITLE
feat: emphasize red trajectory painting

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -10,20 +10,16 @@
     "line_width": 1.0
   },
   "trajectory": {
-    "color": "#2563EB",
-    "ghost_color": "#93C5FD",
-    "line_width": 3.0,
-    "ball_radius": 0.6
+    "color": "#DC2626",
+    "ball_color": "#DC2626",
+    "line_width": 6,
+    "ball_radius": 1.0,
+    "always_on_top": true
   },
   "animation": {
     "mode": "reveal_with_ball",
     "duration_seconds": 1.5,
     "ease": "linear",
-    "ghost": {
-      "enabled": true,
-      "segments": 80,
-      "opacity": 0.35
-    },
     "strict_direction": true
   },
   "overlay": {


### PR DESCRIPTION
## Summary
- switch the default viewer theme to a bold red trajectory, larger ball, and always-on-top rendering
- replace the ghost trail with incremental vertex coloring so the flight path stays painted red
- ensure the ball uses the configured color and enlarged radius while keeping the line drawn above the park wires

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbbb8136cc8326af790e96cecd585c