### PR TITLE
Implement synchronized trajectory rendering

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -13,14 +13,11 @@
     "color": "#DC2626",
     "ball_color": "#DC2626",
     "line_width": 6,
-    "ball_radius": 1.0,
-    "always_on_top": true
+    "ball_radius": 1.0
   },
   "animation": {
-    "mode": "reveal_with_ball",
-    "duration_seconds": 1.5,
-    "ease": "linear",
-    "strict_direction": true
+    "mode": "sync_line_and_ball",
+    "duration_seconds": 1.5
   },
   "overlay": {
     "text_color": "#333333"


### PR DESCRIPTION
## Summary
- replace the reveal/background trajectories with a single synchronous line and ball animation that advances together by draw range
- harden trajectory normalisation to filter bad data, enforce home-to-outfield ordering, and warn while keeping a fallback marker when too few points are available
- update the default theme to use the new sync mode and remove obsolete always-on-top settings

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68dbc26608e883268538479951a68212