### PR TITLE
Lighten ballpark wireframe lines

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -903,7 +903,7 @@ function addGroundGrid() {
 }
 
 function addBallparkWireframe(ballpark) {
-  const lineColor = new THREE.Color(theme.ballpark?.line_color || '#8892a6');
+  const lineColor = new THREE.Color(theme.ballpark?.line_color || '#f5f5f5');
   const lineWidth = theme.ballpark?.line_width || 1;
   const material = new THREE.LineBasicMaterial({color: lineColor, linewidth: lineWidth});
   const toVec = (p) => {


### PR DESCRIPTION
## Summary
- set the default ballpark wireframe color to a very light gray so stadium outlines recede visually

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbee29711c8326a1ddea28cbb2ed3b