### PR TITLE
Set stadium wireframe default color to white

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -903,7 +903,7 @@ function addGroundGrid() {
 }
 
 function addBallparkWireframe(ballpark) {
-  const lineColor = new THREE.Color(theme.ballpark?.line_color || '#f5f5f5');
+  const lineColor = new THREE.Color(theme.ballpark?.line_color || '#ffffff');
   const lineWidth = theme.ballpark?.line_width || 1;
   const material = new THREE.LineBasicMaterial({color: lineColor, linewidth: lineWidth});
   const toVec = (p) => {


### PR DESCRIPTION
## Summary
- update the default ballpark wireframe color fallback to white so the stadium outline is less prominent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbefda1a208326b02ba2d117828848