### PR TITLE
Ensure ballpark lines render white

### DIFF
--- a/config/theme.json
+++ b/config/theme.json
@@ -1,7 +1,7 @@
 {
   "background": "#f5f7fb",
   "ballpark": {
-    "line_color": "#8892a6",
+    "line_color": "#ffffff",
     "line_width": 1.0
   },
   "ground_grid": {

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,8 @@
+import json
+from pathlib import Path
+
+def test_ballpark_line_color_is_white():
+    theme_path = Path(__file__).resolve().parent.parent / "config" / "theme.json"
+    with theme_path.open() as f:
+        theme = json.load(f)
+    assert theme["ballpark"]["line_color"].lower() == "#ffffff"


### PR DESCRIPTION
## Summary
- set the ballpark line color theme value to pure white
- add a regression test to ensure the ballpark line color stays white

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf1e238c4832680b5ea5ba596dee1