### PR TITLE
Add 0.75× playback speed option

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -27,6 +27,7 @@
         <label>Speed
           <select id="selSpeed">
             <option value="0.5">0.5×</option>
+            <option value="0.75">0.75×</option>
             <option value="1" selected>1×</option>
             <option value="2">2×</option>
           </select>


### PR DESCRIPTION
## Summary
- add a 0.75× choice to the playback speed selector for finer control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc3741e5288326b76ffc9fc76f8789